### PR TITLE
Make application faster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     container_name: pimcore-php-fpm
     working_dir: /application
     volumes:
-      - .:/application
+      - .:/application:cached
       - ./.docker/php-fpm/php-ini-overrides.ini:/etc/php/7.1/fpm/conf.d/99-overrides.ini
     links:
      - mariadb:mariadb


### PR DESCRIPTION
By enabling the `:cached` option files get served faster and docker runs smoother.