### PR TITLE
Use correct commands to configure InnoDB system variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: mariadb:10.1
     container_name: pimcore-mariadb
     working_dir: /application
-    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb_file_format=Barracuda, --innodb_large_prefix=1, --innodb_file_per_table=1]
+    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-format=Barracuda, --innodb-large-prefix=1, --innodb-file-per-table=1]
     volumes:
       - pimcore-database:/var/lib/mysql
     environment:


### PR DESCRIPTION
According to this https://mariadb.com/kb/en/library/innodb-system-variables/ InnoDB commands are separated with dashes instead of underscores.